### PR TITLE
Serializerrefactor

### DIFF
--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -588,7 +588,7 @@ func (c *dnd5eAPI) ListSkills() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToSkill(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil
@@ -621,7 +621,7 @@ func (c *dnd5eAPI) GetSkill(key string) (*entities.Skill, error) {
 		Key:          response.Index,
 		Name:         response.Name,
 		Descricption: response.Description,
-		AbilityScore: referenceItemToAbilityScore(response.AbilityScore),
+		AbilityScore: referenceItemToReferenceItem(response.AbilityScore),
 		Type:         urlToType(response.URL),
 	}
 

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -209,7 +209,7 @@ func (c *dnd5eAPI) ListClasses() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToClass(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil
@@ -247,7 +247,7 @@ func (c *dnd5eAPI) GetClass(key string) (*entities.Class, error) {
 		Name:                     response.Name,
 		HitDie:                   response.HitDie,
 		Proficiencies:            referenceItemsToReferenceItems(response.Proficiencies),
-		SavingThrows:             savingThrowResultsToSavingThrows(response.SavingThrows),
+		SavingThrows:             referenceItemsToReferenceItems(response.SavingThrows),
 		StartingEquipment:        startingEquipmentResultsToStartingEquipment(response.StartingEquipment),
 		ProficiencyChoices:       choiceResultsToChoices(response.ProficiencyChoices),
 		StartingEquipmentOptions: startingEquipmentOption,
@@ -752,7 +752,7 @@ func (c *dnd5eAPI) GetClassLevel(key string, level int) (*entities.Level, error)
 		SpellCasting:        spellCastingResultToSpellCasting(response.SpellCasting),
 		ClassSpecific:       levelResultToClassSpecific(response),
 		Key:                 response.Index,
-		Class:               referenceItemToClass(response.Class),
+		Class:               referenceItemToReferenceItem(response.Class),
 	}
 
 	return classLevel, nil

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -652,7 +652,7 @@ func (c *dnd5eAPI) ListMonsters() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToMonster(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -246,7 +246,7 @@ func (c *dnd5eAPI) GetClass(key string) (*entities.Class, error) {
 		Key:                      response.Index,
 		Name:                     response.Name,
 		HitDie:                   response.HitDie,
-		Proficiencies:            proficiencyResultsToProficiencies(response.Proficiencies),
+		Proficiencies:            referenceItemsToReferenceItems(response.Proficiencies),
 		SavingThrows:             savingThrowResultsToSavingThrows(response.SavingThrows),
 		StartingEquipment:        startingEquipmentResultsToStartingEquipment(response.StartingEquipment),
 		ProficiencyChoices:       choiceResultsToChoices(response.ProficiencyChoices),

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -519,7 +519,7 @@ func (c *dnd5eAPI) ListFeatures() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToFeature(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil
@@ -552,7 +552,7 @@ func (c *dnd5eAPI) GetFeature(key string) (*entities.Feature, error) {
 		Key:   response.Index,
 		Name:  response.Name,
 		Level: response.Level, //TODO: add prerequisites?
-		Class: featureClassResultToClass(response.Class),
+		Class: referenceItemToReferenceItem(response.Class),
 	}
 
 	if response.FeatureSpecific != nil {
@@ -748,7 +748,7 @@ func (c *dnd5eAPI) GetClassLevel(key string, level int) (*entities.Level, error)
 		Level:               response.Level,
 		AbilityScoreBonuses: response.AbilityScoreBonuses,
 		ProfBonus:           response.ProfBonus,
-		Features:            referenceItemsToFeatures(response.Features),
+		Features:            referenceItemsToReferenceItems(response.Features),
 		SpellCasting:        spellCastingResultToSpellCasting(response.SpellCasting),
 		ClassSpecific:       levelResultToClassSpecific(response),
 		Key:                 response.Index,

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -53,7 +53,7 @@ func (c *dnd5eAPI) ListRaces() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToRace(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil
@@ -81,10 +81,10 @@ func (c *dnd5eAPI) GetRace(key string) (*entities.Race, error) {
 		Name:                       response.Name,
 		Speed:                      response.Speed,
 		AbilityBonuses:             abilityBonusResultsToAbilityBonuses(response.AbilityBonus),
-		Languages:                  languageResultsToLanguages(response.Language),
-		Traits:                     traitResultsToTraits(response.Trait),
-		SubRaces:                   subRaceResultsToSubRaces(response.SubRaces),
-		StartingProficiencies:      proficiencyResultsToProficiencies(response.StartingProficiencies),
+		Languages:                  referenceItemsToReferenceItems(response.Language),
+		Traits:                     referenceItemsToReferenceItems(response.Trait),
+		SubRaces:                   referenceItemsToReferenceItems(response.SubRaces),
+		StartingProficiencies:      referenceItemsToReferenceItems(response.StartingProficiencies),
 		StartingProficiencyOptions: choiceResultToChoice(response.StartingProficiencyOptions),
 		LanguageOptions:            choiceResultToChoice(response.LanguageOptions),
 	}
@@ -111,7 +111,7 @@ func (c *dnd5eAPI) ListEquipment() ([]*entities.ReferenceItem, error) {
 
 	out := make([]*entities.ReferenceItem, len(response.Results))
 	for i, r := range response.Results {
-		out[i] = referenceItemToEquipment(r)
+		out[i] = referenceItemToReferenceItem(r)
 	}
 
 	return out, nil

--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -356,7 +356,7 @@ func (c *dnd5eAPI) ListSpells(input *ListSpellsInput) ([]*entities.ReferenceItem
 
 		levelOut := make([]*entities.ReferenceItem, len(levelList))
 		for i, r := range levelList {
-			levelOut[i] = referenceItemToSpell(r)
+			levelOut[i] = referenceItemToReferenceItem(r)
 		}
 
 		return levelOut, nil
@@ -370,7 +370,7 @@ func (c *dnd5eAPI) ListSpells(input *ListSpellsInput) ([]*entities.ReferenceItem
 
 		classOut := make([]*entities.ReferenceItem, len(classList))
 		for i, r := range classList {
-			classOut[i] = referenceItemToSpell(r)
+			classOut[i] = referenceItemToReferenceItem(r)
 		}
 
 		return classOut, nil
@@ -394,7 +394,7 @@ func (c *dnd5eAPI) ListSpells(input *ListSpellsInput) ([]*entities.ReferenceItem
 	out := make([]*entities.ReferenceItem, 0)
 	for _, r := range classList {
 		if levelMap[r.Index] {
-			out = append(out, referenceItemToSpell(r))
+			out = append(out, referenceItemToReferenceItem(r))
 		}
 	}
 
@@ -488,8 +488,8 @@ func (c *dnd5eAPI) GetSpell(key string) (*entities.Spell, error) {
 		SpellDamage:   spellDamageResultToSpellDamage(response.SpellDamage),
 		DC:            dcResultToDC(response.DC),
 		AreaOfEffect:  areaOfEffectResultToAreaOfEffect(response.AreaOfEffect),
-		SpellSchool:   spellSchoolResultToSpellSchool(response.SpellSchool),
-		SpellClasses:  spellClassResultsToSpellClasses(response.SpellClasses),
+		SpellSchool:   referenceItemToReferenceItem(response.SpellSchool),
+		SpellClasses:  referenceItemsToReferenceItems(response.SpellClasses),
 	}
 
 	return spell, nil

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -217,28 +217,6 @@ func choiceResultsToChoices(input []*choiceResult) []*entities.ChoiceOption {
 	return out
 }
 
-func referenceItemToSkill(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func referenceItemToAbilityScore(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func referenceItemToMonster(input *referenceItem) *entities.ReferenceItem {
 	if input == nil {
 		return nil

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -4,13 +4,6 @@ import (
 	"github.com/fadedpez/dnd5e-api/entities"
 )
 
-func referenceItemToRace(input *referenceItem) *entities.ReferenceItem {
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func abilityBonusResultToAbilityBonus(input *abilityBonus) *entities.AbilityBonus {
 	if input == nil {
 		return nil
@@ -34,66 +27,6 @@ func abilityBonusResultsToAbilityBonuses(input []*abilityBonus) []*entities.Abil
 	return out
 }
 
-func languageResultToLanguage(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func languageResultsToLanguages(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, l := range input {
-		out[i] = languageResultToLanguage(l)
-	}
-
-	return out
-}
-
-func traitResultToTrait(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func traitResultsToTraits(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, t := range input {
-		out[i] = traitResultToTrait(t)
-	}
-
-	return out
-}
-
-func subRaceResultToSubRace(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func subRaceResultsToSubRaces(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, s := range input {
-		out[i] = subRaceResultToSubRace(s)
-	}
-
-	return out
-}
-
 func referenceItemToProficiency(input *referenceItem) *entities.ReferenceItem {
 	if input == nil {
 		return nil
@@ -112,13 +45,6 @@ func proficiencyResultsToProficiencies(input []*referenceItem) []*entities.Refer
 	}
 
 	return out
-}
-
-func referenceItemToEquipment(input *referenceItem) *entities.ReferenceItem {
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
 }
 
 func equipmentCategoryResultToEquipmentCategory(input *referenceItem) *entities.ReferenceItem {
@@ -864,6 +790,7 @@ func typeStringToProficiencyType(input string) entities.ProficiencyType {
 		return entities.ProficiencyTypeUnknown
 	}
 }
+
 func referenceItemsToReferenceItems(input []*referenceItem) []*entities.ReferenceItem {
 	if input == nil {
 		return nil

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -196,37 +196,6 @@ func areaOfEffectResultToAreaOfEffect(input *areaOfEffect) *entities.AreaOfEffec
 	}
 }
 
-func referenceItemToFeature(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func referenceItemsToFeatures(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, s := range input {
-		out[i] = referenceItemToFeature(s)
-	}
-
-	return out
-}
-
-func featureClassResultToClass(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func choiceResultToChoice(input *choiceResult) *entities.ChoiceOption {
 	if input == nil {
 		return nil

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -125,51 +125,13 @@ func armorClassResultToArmorClass(input *armorClass) *entities.ArmorClass {
 	}
 }
 
-func referenceItemToClass(input *referenceItem) *entities.ReferenceItem {
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func savingThrowResultToSavingThrow(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func savingThrowResultsToSavingThrows(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, s := range input {
-		out[i] = savingThrowResultToSavingThrow(s)
-	}
-
-	return out
-}
-
-func equipmentListResultToEquipmentList(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func startingEquipmentResultToStartingEquipment(input *startingEquipment) *entities.StartingEquipment {
 	if input == nil {
 		return nil
 	}
 
 	return &entities.StartingEquipment{
-		Equipment: equipmentListResultToEquipmentList(input.Equipment),
+		Equipment: referenceItemToReferenceItem(input.Equipment),
 		Quantity:  input.Quantity,
 	}
 }

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -217,17 +217,6 @@ func choiceResultsToChoices(input []*choiceResult) []*entities.ChoiceOption {
 	return out
 }
 
-func referenceItemToMonster(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func monsterSpeedResultToSpeed(input *monsterSpeed) *entities.Speed {
 	if input == nil {
 		return nil

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -145,36 +145,14 @@ func startingEquipmentResultsToStartingEquipment(input []*startingEquipment) []*
 	return out
 }
 
-func referenceItemToSpell(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func spellDamageResultToSpellDamage(input *spellDamage) *entities.SpellDamage {
 	if input == nil {
 		return nil
 	}
 
 	return &entities.SpellDamage{
-		SpellDamageType:        spellDamageTypeResultToSpellDamageType(input.DamageType),
+		SpellDamageType:        referenceItemToReferenceItem(input.DamageType),
 		SpellDamageAtSlotLevel: spellDamageAtSlotLevelToSpellDamageAtSlotLevel(input.DamageAtSlotLevel),
-	}
-}
-
-func spellDamageTypeResultToSpellDamageType(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
 	}
 }
 
@@ -202,32 +180,9 @@ func dcResultToDC(input *dc) *entities.DC {
 	}
 
 	return &entities.DC{
-		DCType:    dcTypeResultToDCType(input.DCType),
+		DCType:    referenceItemToReferenceItem(input.DCType),
 		DCSuccess: input.DCSuccess,
 	}
-}
-
-func dcTypeResultToDCType(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func spellClassResultsToSpellClasses(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, s := range input {
-		out[i] = &entities.ReferenceItem{
-			Key:  s.Index,
-			Name: s.Name,
-		}
-	}
-
-	return out
 }
 
 func areaOfEffectResultToAreaOfEffect(input *areaOfEffect) *entities.AreaOfEffect {
@@ -238,17 +193,6 @@ func areaOfEffectResultToAreaOfEffect(input *areaOfEffect) *entities.AreaOfEffec
 	return &entities.AreaOfEffect{
 		Type: input.Type,
 		Size: input.Size,
-	}
-}
-
-func spellSchoolResultToSpellSchool(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
 	}
 }
 

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -61,39 +61,8 @@ func damageResultToDamage(input *damage) *entities.Damage {
 
 	return &entities.Damage{
 		DamageDice: input.DamageDice,
-		DamageType: damageTypeResultToDamageType(input.DamageType),
+		DamageType: referenceItemToReferenceItem(input.DamageType),
 	}
-}
-
-func damageTypeResultToDamageType(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func propertyResultToProperties(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func propertiesResultsToProperties(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, p := range input {
-		out[i] = propertyResultToProperties(p)
-	}
-
-	return out
 }
 
 func weaponRangeResultToWeaponRange(input *weaponRange) *entities.Range {
@@ -122,7 +91,7 @@ func weaponResultToWeapon(input *weaponResult) *entities.Weapon {
 		WeaponRange:       input.WeaponRange,
 		CategoryRange:     input.CategoryRange,
 		Range:             weaponRangeResultToWeaponRange(input.Range),
-		Properties:        propertiesResultsToProperties(input.Properties),
+		Properties:        referenceItemsToReferenceItems(input.Properties),
 		TwoHandedDamage:   damageResultToDamage(input.TwoHandedDamage),
 	}
 }

--- a/clients/dnd5e/serializers.go
+++ b/clients/dnd5e/serializers.go
@@ -27,37 +27,6 @@ func abilityBonusResultsToAbilityBonuses(input []*abilityBonus) []*entities.Abil
 	return out
 }
 
-func referenceItemToProficiency(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
-func proficiencyResultsToProficiencies(input []*referenceItem) []*entities.ReferenceItem {
-	out := make([]*entities.ReferenceItem, len(input))
-	for i, p := range input {
-		out[i] = referenceItemToProficiency(p)
-	}
-
-	return out
-}
-
-func equipmentCategoryResultToEquipmentCategory(input *referenceItem) *entities.ReferenceItem {
-	if input == nil {
-		return nil
-	}
-
-	return &entities.ReferenceItem{
-		Key:  input.Index,
-		Name: input.Name,
-	}
-}
-
 func costResultToCost(input *cost) *entities.Cost {
 	if input == nil {
 		return nil
@@ -79,7 +48,7 @@ func equipmentResultToEquipment(input *equipmentResult) *entities.Equipment {
 		Name:   input.Name,
 		Cost:   costResultToCost(input.Cost),
 		Weight: input.Weight,
-		EquipmentCategory: equipmentCategoryResultToEquipmentCategory(
+		EquipmentCategory: referenceItemToReferenceItem(
 			input.EquipmentCategory,
 		),
 	}
@@ -148,7 +117,7 @@ func weaponResultToWeapon(input *weaponResult) *entities.Weapon {
 		Cost:              costResultToCost(input.Cost),
 		Damage:            damageResultToDamage(input.Damage),
 		Weight:            input.Weight,
-		EquipmentCategory: equipmentCategoryResultToEquipmentCategory(input.EquipmentCategory),
+		EquipmentCategory: referenceItemToReferenceItem(input.EquipmentCategory),
 		WeaponCategory:    input.WeaponCategory,
 		WeaponRange:       input.WeaponRange,
 		CategoryRange:     input.CategoryRange,
@@ -172,7 +141,7 @@ func armorResultToArmor(input *armorResult) *entities.Armor {
 		StrMinimum:          input.StrMinimum,
 		StealthDisadvantage: input.StealthDisadvantage,
 		Weight:              input.Weight,
-		EquipmentCategory:   equipmentCategoryResultToEquipmentCategory(input.EquipmentCategory),
+		EquipmentCategory:   referenceItemToReferenceItem(input.EquipmentCategory),
 	}
 }
 
@@ -457,7 +426,7 @@ func monsterProficiencyResultToMonsterProficiency(input *monsterProficiency) *en
 	}
 
 	return &entities.MonsterProficiency{
-		Proficiency: referenceItemToProficiency(input.Proficiency),
+		Proficiency: referenceItemToReferenceItem(input.Proficiency),
 		Value:       input.Value,
 	}
 }

--- a/entities/reference_item.go
+++ b/entities/reference_item.go
@@ -1,22 +1,7 @@
 package entities
 
-import "strings"
-
 type ReferenceItem struct {
 	Key  string `json:"index"`
 	Name string `json:"name"`
-	Type string `json:"url"`
-}
-
-func (r *ReferenceItem) GetType() string {
-	if r.Type == "" {
-		return ""
-	}
-
-	parts := strings.Split(r.Type, "/")
-	if len(parts) < 2 || len(parts) > 4 {
-		return ""
-	}
-
-	return parts[len(parts)-2]
+	Type string `json:"type"`
 }


### PR DESCRIPTION
There were many * to reference item serializers, now there is only one and all previous usages replaced with the single serializer. 

There were many * to reference items serializers, now there is only one and all preivous usages replaced with the single serializer.

closes: fadedpez/dnd5e-api/issues/97