### PR TITLE
add equipement categories

### DIFF
--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -876,3 +876,28 @@ func (c *dnd5eAPI) GetDamageType(key string) (*entities.DamageType, error) {
 
 	return damageType, nil
 }
+
+func (c *dnd5eAPI) GetEquipmentCategory(key string) (*entities.EquipmentCategory, error) {
+	resp, err := c.client.Get(baserulzURL + "equipment-categories/" + key)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, errors.New(fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	category := &entities.EquipmentCategory{}
+	err = json.Unmarshal(responseBody, category)
+	if err != nil {
+		return nil, err
+	}
+
+	return category, nil
+}

--- a/clients/dnd5e/interface.go
+++ b/clients/dnd5e/interface.go
@@ -23,6 +23,7 @@ type Interface interface {
 	GetMonster(key string) (*entities.Monster, error)
 	GetClassLevel(key string, level int) (*entities.Level, error)
 	GetProficiency(key string) (*entities.Proficiency, error)
+	GetEquipmentCategory(key string) (*entities.EquipmentCategory, error)
 }
 
 type httpIface interface {

--- a/entities/equipment_category.go
+++ b/entities/equipment_category.go
@@ -1,0 +1,9 @@
+package entities
+
+// EquipmentCategory represents a category of equipment (e.g., martial-weapons)
+type EquipmentCategory struct {
+	Index     string          `json:"index"`
+	Name      string          `json:"name"`
+	Equipment []*ReferenceItem `json:"equipment"`
+	URL       string          `json:"url"`
+}


### PR DESCRIPTION
This pull request adds support for retrieving equipment category data from the D&D 5e API. The most important changes include implementing a new method in the `dnd5eAPI` client, updating the client interface, and introducing a new `EquipmentCategory` entity.

### New functionality for equipment categories:

* [`clients/dnd5e/dnd5eapi.go`](diffhunk://#diff-8248af3b30666e798c6a262498a838b95ffaac372c760f1ffa70b9f3174004f1R879-R903): Added the `GetEquipmentCategory` method to fetch equipment category data from the D&D 5e API, including error handling and response parsing.
* [`clients/dnd5e/interface.go`](diffhunk://#diff-0ae07992b05cc32525be26182df7af5a0a5446a2d1a1b8d7f783dfef18b61125R26): Updated the `Interface` type to include the new `GetEquipmentCategory` method.

### New entity definition:

* [`entities/equipment_category.go`](diffhunk://#diff-6c0506f974825b9382301c86759b08a16933c793d54228093437b8a82a6aabbfR1-R9): Introduced the `EquipmentCategory` struct to represent equipment category data, including fields for `Index`, `Name`, `Equipment`, and `URL`.