### PR TITLE
Add Size and SizeDescription fields to Race entity

### DIFF
--- a/clients/dnd5e/dnd5eapi.go
+++ b/clients/dnd5e/dnd5eapi.go
@@ -98,6 +98,8 @@ func (c *dnd5eAPI) GetRace(key string) (*entities.Race, error) {
 		Key:                        response.Index,
 		Name:                       response.Name,
 		Speed:                      response.Speed,
+		Size:                       response.Size,
+		SizeDescription:            response.SizeDescription,
 		AbilityBonuses:             abilityBonusResultsToAbilityBonuses(response.AbilityBonus),
 		Languages:                  referenceItemsToReferenceItems(response.Language),
 		Traits:                     referenceItemsToReferenceItems(response.Trait),

--- a/clients/dnd5e/types.go
+++ b/clients/dnd5e/types.go
@@ -10,6 +10,8 @@ type raceResult struct {
 	Index                      string           `json:"index"`
 	Name                       string           `json:"name"`
 	Speed                      int              `json:"speed"`
+	Size                       string           `json:"size"`
+	SizeDescription            string           `json:"size_description"`
 	AbilityBonus               []*abilityBonus  `json:"ability_bonuses"`
 	Language                   []*referenceItem `json:"languages"`
 	Trait                      []*referenceItem `json:"traits"`

--- a/entities/race.go
+++ b/entities/race.go
@@ -4,6 +4,8 @@ type Race struct {
 	Key                        string           `json:"key"`
 	Name                       string           `json:"name"`
 	Speed                      int              `json:"speed"`
+	Size                       string           `json:"size"`
+	SizeDescription            string           `json:"size_description"`
 	AbilityBonuses             []*AbilityBonus  `json:"ability_bonuses"`
 	Languages                  []*ReferenceItem `json:"languages"`
 	Traits                     []*ReferenceItem `json:"traits"`


### PR DESCRIPTION
## Summary
- Added Size and SizeDescription fields to Race entity to support character creation systems
- Updated API response parsing to include size information from D&D 5e API
- All existing functionality preserved with backward compatibility

## Changes Made
- Modified `entities/race.go` to add Size and SizeDescription fields
- Updated `clients/dnd5e/types.go` raceResult struct to parse size fields from API
- Updated `clients/dnd5e/dnd5eapi.go` GetRace mapping to include new fields
- Cached client automatically inherits the changes through delegation

## Testing
- All existing tests pass
- Verified new fields are populated correctly from API response
- Tested with Dragonborn race: Size="Medium", SizeDescription="Dragonborn are taller and heavier than humans..."

## Fixes
Closes #121

🤖 Generated with [Claude Code](https://claude.ai/code)